### PR TITLE
Fix Recording Error

### DIFF
--- a/maze_2d/maze_2d_q_learning.py
+++ b/maze_2d/maze_2d_q_learning.py
@@ -181,9 +181,9 @@ if __name__ == "__main__":
     recording_folder = "/tmp/maze_q_learning"
 
     if ENABLE_RECORDING:
-        env.monitor.start(recording_folder, force=True)
+        env = gym.wrappers.Monitor(env, recording_folder, force=True)
 
     simulate()
 
     if ENABLE_RECORDING:
-        env.monitor.close()
+        env.close()


### PR DESCRIPTION
'env.monitor.start(recording_folder, force=True)' is no longer working with the latest gym library. 
Updated to 'gym.wrappers.Monitor(env, recording_folder, force=True)' in order it to work as expected.